### PR TITLE
DM-13163: Refactor ap_pipe to use CmdLineTask primitives

### DIFF
--- a/policy/ctio0m9Mapper.paf
+++ b/policy/ctio0m9Mapper.paf
@@ -464,4 +464,7 @@ datasets: {
         tables: raw
         tables: raw_visit
     }
+    apPipe_metadata: {
+        template:      "apPipe_metadata/v%(visit)d_f%(filter)s.boost"
+    }
 }


### PR DESCRIPTION
This PR registers dataset mappings for configs and metadata persisted by `ApPipeTask`.