### PR TITLE
DM-14842: Fix deprecation warnings from PropertyList/Set.get

### DIFF
--- a/python/lsst/obs/ctio0m9/ctio0m9Mapper.py
+++ b/python/lsst/obs/ctio0m9/ctio0m9Mapper.py
@@ -46,7 +46,7 @@ class Ctio0m9MakeRawVisitInfo(MakeRawVisitInfo):
         @param[in, out] md the argument dictionary for modification
         """
         super(Ctio0m9MakeRawVisitInfo, self).setArgDict(md, argDict)
-        argDict["darkTime"] = md.get("DARKTIME")
+        argDict["darkTime"] = md.getScalar("DARKTIME")
 
     def getDateAvg(self, md, exposureTime):
         """Return date at the middle of the exposure
@@ -136,8 +136,8 @@ class Ctio0m9Mapper(CameraMapper):
         # Note that setting these must be done before the call to super below
         md.set('CTYPE1', 'RA---TAN') # add missing keywords
         md.set('CTYPE2', 'DEC--TAN') # add missing keywords
-        md.set('CRVAL2', decStrToDeg(md.get('DEC'))) # translate RA/DEC from header
-        md.set('CRVAL1', raStrToDeg(md.get('RA')))
+        md.set('CRVAL2', decStrToDeg(md.getScalar('DEC'))) # translate RA/DEC from header
+        md.set('CRVAL1', raStrToDeg(md.getScalar('RA')))
         md.set('CRPIX1', 210.216) # set reference pixels
         md.set('CRPIX2', 344.751)
         md.set('CD1_1', -0.000111557869436) # set nominal CD matrix
@@ -154,7 +154,7 @@ class Ctio0m9Mapper(CameraMapper):
         # we need to so so.
         #
         ccd = item.getDetector()
-        rawBBoxFromMetadata = bboxFromIraf(md.get("ASEC11"))
+        rawBBoxFromMetadata = bboxFromIraf(md.getScalar("ASEC11"))
         rawBBox = ccd[0].getRawBBox()
 
         if rawBBoxFromMetadata != rawBBox:
@@ -167,8 +167,8 @@ class Ctio0m9Mapper(CameraMapper):
             for a in ccd:
                 ix, iy = [int(_) for _ in a.getName()]
                 irafName = "%d%d" % (iy, ix)
-                a.setRawBBox(bboxFromIraf(md.get("ASEC%s" % irafName)))
-                a.setRawDataBBox(bboxFromIraf(md.get("TSEC%s" % irafName)))
+                a.setRawBBox(bboxFromIraf(md.getScalar("ASEC%s" % irafName)))
+                a.setRawDataBBox(bboxFromIraf(md.getScalar("TSEC%s" % irafName)))
 
                 if extraSerialOverscan != 0 or extraParallelOverscan != 0:
                     #
@@ -224,7 +224,7 @@ def sanitize_date(md):
     @param md      metadata in, to be fixed
     @return md     metadata returned, with DATE-OBS fixed
     '''
-    date_obs = md.get('DATE-OBS')
+    date_obs = md.getScalar('DATE-OBS')
     try: # see if compliant. Don't use, just a test with dafBase
         dt = dafBase.DateTime(date_obs, dafBase.DateTime.TAI)
     except: #if bad, sanitise

--- a/python/lsst/obs/ctio0m9/ingest.py
+++ b/python/lsst/obs/ctio0m9/ingest.py
@@ -51,7 +51,7 @@ class Ctio0m9ParseTask(ParseTask):
 
         @param[in] md image metadata
         """
-        return mjdToVisit(md.get("DATE-OBS"))
+        return mjdToVisit(md.getScalar("DATE-OBS"))
 
     def translate_imgType(self, md):
         """Determine the type of image being taken (bias, dark etc).
@@ -63,7 +63,7 @@ class Ctio0m9ParseTask(ParseTask):
         @param[in] md image metadata
         @return The image type, as mapped by the dict in this function
         """
-        val = md.get("IMAGETYP").rstrip().lstrip()
+        val = md.getScalar("IMAGETYP").rstrip().lstrip()
         conversion = {'dflat': 'flat',
                       'DFLAT': 'flat',
                       'DOME FLAT': 'flat',
@@ -91,7 +91,7 @@ class Ctio0m9ParseTask(ParseTask):
         @param[in] md image metadata
         @return wavelength in nm
         """
-        val = md.get("OBJECT").rstrip().lstrip()
+        val = md.getScalar("OBJECT").rstrip().lstrip()
         if self.translate_imgType(md) != 'flat':
             return float('nan') # defaults to NaN if not a flat
         if val[0:4].isdigit():
@@ -151,8 +151,8 @@ class Ctio0m9ParseTask(ParseTask):
         @param[in] md image metadata
         @return sanitized and concatenated filter name
         """
-        filt1 = self._translate_filter(md.get("FILTER1").rstrip().lstrip())
-        filt2 = self._translate_filter(md.get("FILTER2").rstrip().lstrip())
+        filt1 = self._translate_filter(md.getScalar("FILTER1").rstrip().lstrip())
+        filt2 = self._translate_filter(md.getScalar("FILTER2").rstrip().lstrip())
         sorted_filter = [filt1, filt2]
         sorted_filter.sort() #we want to be insensitive to filter order, for now at least
         filter_name = '+'.join(_ for _ in sorted_filter)
@@ -165,7 +165,7 @@ class Ctio0m9ParseTask(ParseTask):
         @return compliant DATE-OBS string
         """
         md = sanitize_date(md)
-        return md.get('DATE-OBS')
+        return md.getScalar('DATE-OBS')
 
     def translate_filter1(self, md):
         """Standardize the filter naming.
@@ -176,7 +176,7 @@ class Ctio0m9ParseTask(ParseTask):
         @param[in] md image metadata
         @return sanitized filter name
         """
-        val = md.get("FILTER1").rstrip().lstrip()
+        val = md.getScalar("FILTER1").rstrip().lstrip()
         return self._translate_filter(val)
 
     def translate_filter2(self, md):
@@ -188,7 +188,7 @@ class Ctio0m9ParseTask(ParseTask):
         @param[in] md image metadata
         @return sanitized filter name
         """
-        val = md.get("FILTER2").rstrip().lstrip()
+        val = md.getScalar("FILTER2").rstrip().lstrip()
         return self._translate_filter(val)
 
 
@@ -197,7 +197,7 @@ class Ctio0m9CalibsParseTask(CalibsParseTask):
 
     def _translateFromCalibId(self, field, md):
         """Get a value from the CALIB_ID written by constructCalibs"""
-        data = md.get("CALIB_ID")
+        data = md.getScalar("CALIB_ID")
         match = re.search(".*%s=(\S+)" % field, data)
         return match.groups()[0]
 


### PR DESCRIPTION
Use `getScalar` or `getArray` instead of deprecated `get`
on `PropertySet` and `PropertyList` instances.