### PR TITLE
DM-6640: IsrTask is not a valid CmdLineTask

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -1,0 +1,6 @@
+"""
+ctio0m9-specific overrides for IsrTask
+"""
+config.doFlat = False # TODO: change for release/when we have flats
+config.doLinearize = False
+config.doDefect = False # TODO: make defect list and enable

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -1,12 +1,17 @@
+"""
+ctio0m9-specific overrides for ProcessCcdTask
+"""
 from __future__ import print_function
+import os.path
 from lsst.meas.algorithms import LoadIndexedReferenceObjectsTask
 from lsst.meas.astrom import MatchPessimisticBTask
+from lsst.utils import getPackageDir
+
+obsConfigDir = os.path.join(getPackageDir("obs_ctio0m9"), "config")
 
 PIXEL_MARGIN = 2000 # to ensure they're linked, as per DM-11356
 
-config.isr.doFlat = False # TODO: change for release/when we have flats
-config.isr.doLinearize = False
-config.isr.doDefect = False # TODO: make defect list and enable
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))
 
 config.charImage.repair.cosmicray.nCrPixelMax = 100000
 

--- a/config/runIsr.py
+++ b/config/runIsr.py
@@ -1,0 +1,10 @@
+"""
+ctio0m9-specific overrides for RunIsrTask
+"""
+import os.path
+
+from lsst.utils import getPackageDir
+
+obsConfigDir = os.path.join(getPackageDir("obs_ctio0m9"), "config")
+
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))


### PR DESCRIPTION
This ticket adds a stand-alone runIsr.py script, as well as ensuring that runIsr.py and processCcd.py read the same ISR configuration files.
