### PR TITLE
DM-18610: Add fields, limited mutability, and trim/assembly-state tracking to cameraGeom

### DIFF
--- a/config/bias.py
+++ b/config/bias.py
@@ -1,3 +1,4 @@
 config.ccdKeys = []
 config.isr.doLinearize = False
 config.isr.doDefect = False
+config.isr.doSuspect = False

--- a/config/dark.py
+++ b/config/dark.py
@@ -2,3 +2,4 @@ config.ccdKeys = []
 config.isr.doLinearize = False
 config.isr.doDefect = False
 config.isr.doBias = True
+config.isr.doSuspect = False

--- a/config/flat.py
+++ b/config/flat.py
@@ -3,3 +3,4 @@ config.isr.doLinearize = False
 config.isr.doDefect = False
 config.isr.doBias = True
 config.isr.doDark = False
+config.isr.doSuspect = False

--- a/config/isr.py
+++ b/config/isr.py
@@ -4,3 +4,4 @@ ctio0m9-specific overrides for IsrTask
 config.doFlat = False # TODO: change for release/when we have flats
 config.doLinearize = False
 config.doDefect = False # TODO: make defect list and enable
+config.doSuspect = False


### PR DESCRIPTION
This now says suspectLevel = 0, which means it blanks everything.  Disable doSuspect.